### PR TITLE
feat(github-oidc_iam-role): improve trust policy config

### DIFF
--- a/github-oidc-iam-role/README.md
+++ b/github-oidc-iam-role/README.md
@@ -44,6 +44,14 @@ module "oidc_github_iam_role" {
     "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
   ]
 
+  repo_owners = [
+    "my-owner"
+  ]
+
+  sub = [
+    "repo:my-owner/my-repo:ref:refs/heads/*"
+  ]
+
   tags = {
     Project     = "my-project"
     Service     = "my-service"

--- a/github-oidc-iam-role/data.tf
+++ b/github-oidc-iam-role/data.tf
@@ -16,13 +16,27 @@ data "aws_iam_policy_document" "assume_role_policy" {
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:aud"
-      values = ["sts.amazonaws.com"]
+      values   = ["sts.amazonaws.com"]
     }
 
-    condition {
-      test     = "StringLike"
-      variable = "token.actions.githubusercontent.com:sub"
-      values = ["repo:${var.sub}"]
+    dynamic "condition" {
+      for_each = length(var.repo_owners) > 0 ? [1] : [] 
+
+      content {
+        test     = "StringEquals"
+        variable = "token.actions.githubusercontent.com:repository_owner"
+        values   = var.repo_owners
+      }
+    }
+
+    dynamic "condition" {
+      for_each = length(var.sub) > 0 ? [1] : [] 
+
+      content {
+        test     = "StringLike"
+        variable = "token.actions.githubusercontent.com:sub"
+        values   = var.sub
+      }
     }
   }
 }

--- a/github-oidc-iam-role/variables.tf
+++ b/github-oidc-iam-role/variables.tf
@@ -22,9 +22,16 @@ variable "policy_arns" {
   default     = [] 
 }
 
+variable "repo_owners" {
+  type        = set(string)
+  description = "Set of repo owners for the assume role policy"
+  default     = []
+}
+
 variable "sub" {
-  type        = string
+  type        = set(string)
   description = "The sub pattern for the assume role policy (e.g. org/repo:ref:refs/heads/master)"
+  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
- switch `sub` from `string` to `set(string)`
- add `repo_owners` arg for configurability 