### PR TITLE
fix: convert bool to numeric for count argument

### DIFF
--- a/guardrails/s3.tf
+++ b/guardrails/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_account_public_access_block" "this" {
-  count = var.s3.public_access_block.enabled
+  count = var.s3.public_access_block.enabled ? 1 : 0
 
   block_public_acls       = var.s3.public_access_block.block_public_acls
   block_public_policy     = var.s3.public_access_block.block_public_policy


### PR DESCRIPTION
Fixes issue #21

The `count` argument requires a numeric value, but a boolean was being used.
Converted the boolean to numeric using a conditional expression:
enabled ? 1 : 0