### PR TITLE
feat(ses-domain-identity): add spf and refactor

### DIFF
--- a/ses-domain-identity/README.md
+++ b/ses-domain-identity/README.md
@@ -4,6 +4,7 @@ This module allows you to setup domain identification for SES with the following
 
 - Domain verification
 - DKIM
+- SPF
 - DMARC
 
 ## Usage
@@ -12,10 +13,10 @@ See `variables.tf` for the full argument reference.
 
 ```hcl
 module "ses_doamin_identity" {
-  source       = "github.com/script47/aws-tf-modules/ses-domain-identity"
+  source = "github.com/script47/aws-tf-modules/ses-domain-identity"
 
-  hosted_zone         = "my-hosted-zone"
-  domain              = "example.org"
+  zone_id = "zone-id"
+  domain  = "example.org"
 
   domain_verification = {
     ttl = 600
@@ -24,6 +25,13 @@ module "ses_doamin_identity" {
   dkim = {
     enabled = true
     ttl     = 600
+  }
+
+  spf = {
+    enabled  = true
+    includes = ["amazonses.com"] # amazonses.com is default
+    all      = "~all"
+    ttl      = 600
   }
 
   dmarc = {

--- a/ses-domain-identity/data.tf
+++ b/ses-domain-identity/data.tf
@@ -1,4 +1,0 @@
-data "aws_route53_zone" "hosted_zone" {
-  name         = var.hosted_zone
-  private_zone = false
-}

--- a/ses-domain-identity/outputs.tf
+++ b/ses-domain-identity/outputs.tf
@@ -1,0 +1,55 @@
+output "dkim" {
+  value = var.dkim.enabled ? [
+    for token in aws_ses_domain_dkim.this[0].dkim_tokens : {
+      type  = "CNAME"
+      name  = "${token}._domainkey.${var.domain}"
+      value = "${token}.dkim.amazonses.com"
+      ttl   = var.dkim.ttl
+    }
+  ] : []
+}
+output "dns" {
+  value = {
+    domain = var.domain
+    records = concat(
+      [
+        {
+          type  = "TXT"
+          name  = "_amazonses.${var.domain}"
+          value = aws_ses_domain_identity.this.verification_token
+          ttl   = var.domain_verification.ttl
+        }
+      ],
+
+      var.dkim.enabled ? [
+        for token in aws_ses_domain_dkim.this[0].dkim_tokens : {
+          type  = "CNAME"
+          name  = "${token}._domainkey.${var.domain}"
+          value = "${token}.dkim.amazonses.com"
+          ttl   = var.dkim.ttl
+        }
+      ] : [],
+
+      var.spf.enabled ? [{
+        type = "TXT"
+        name = var.domain
+        value = join(
+          " ",
+          concat(
+            ["v=spf1"],
+            [for d in var.spf.includes : "include:${d}"],
+            [var.spf.all]
+          )
+        )
+        ttl = var.spf.ttl
+      }] : [],
+
+      var.dmarc.enabled ? [{
+        type  = "TXT"
+        name  = "_dmarc.${var.domain}"
+        value = var.dmarc.policy
+        ttl   = var.dmarc.ttl
+      }] : []
+    )
+  }
+}

--- a/ses-domain-identity/route53.tf
+++ b/ses-domain-identity/route53.tf
@@ -1,5 +1,19 @@
+locals {
+  configure_dns = var.zone_id != null
+  spf_record = join(
+    " ",
+    concat(
+      ["v=spf1"],
+      [for d in var.spf.includes : "include:${d}"],
+      [var.spf.all]
+    )
+  )
+}
+
 resource "aws_route53_record" "domain_verification" {
-  zone_id = data.aws_route53_zone.hosted_zone.zone_id
+  count = local.configure_dns ? 1 : 0
+
+  zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
   type    = "TXT"
   ttl     = var.domain_verification.ttl
@@ -7,17 +21,32 @@ resource "aws_route53_record" "domain_verification" {
 }
 
 resource "aws_route53_record" "dkim" {
-  count   = var.dkim.enabled ? 3 : 0
-  zone_id = data.aws_route53_zone.hosted_zone.zone_id
+  count = local.configure_dns && var.dkim.enabled ? 3 : 0
+
+  zone_id = var.zone_id
   name    = "${aws_ses_domain_dkim.this[0].dkim_tokens[count.index]}._domainkey.${var.domain}"
   type    = "CNAME"
   ttl     = var.dkim.ttl
   records = ["${aws_ses_domain_dkim.this[0].dkim_tokens[count.index]}.dkim.amazonses.com"]
 }
 
+resource "aws_route53_record" "spf" {
+  count = local.configure_dns && var.spf.enabled ? 1 : 0
+
+  zone_id = var.zone_id
+  name    = var.domain
+  type    = "TXT"
+  ttl     = var.spf.ttl
+
+  records = [
+    local.spf_record
+  ]
+}
+
 resource "aws_route53_record" "dmarc" {
-  count   = var.dmarc.enabled ? 1 : 0
-  zone_id = data.aws_route53_zone.hosted_zone.zone_id
+  count = local.configure_dns && var.dmarc.enabled ? 1 : 0
+
+  zone_id = var.zone_id
   name    = "_dmarc.${var.domain}"
   type    = "TXT"
   ttl     = var.dmarc.ttl

--- a/ses-domain-identity/variables.tf
+++ b/ses-domain-identity/variables.tf
@@ -1,6 +1,7 @@
-variable "hosted_zone" {
+variable "zone_id" {
   type        = string
-  description = "The name of the hosted zone"
+  description = "The ID of the hosted zone"
+  default     = null
 }
 
 variable "domain" {
@@ -18,16 +19,31 @@ variable "domain_verification" {
 variable "dkim" {
   type = object({
     enabled = optional(bool, true)
-    ttl = optional(number, 600)
+    ttl     = optional(number, 600)
   })
   default = {}
+}
+
+variable "spf" {
+  type = object({
+    enabled  = optional(bool, false)
+    includes = optional(list(string), ["amazonses.com"])
+    all      = optional(string, "~all")
+    ttl      = optional(number, 600)
+  })
+  default = {}
+
+  validation {
+    condition     = contains(["~all", "-all"], var.spf.all)
+    error_message = "spf.all must be one of ~all or -all."
+  }
 }
 
 variable "dmarc" {
   type = object({
     enabled = optional(bool, false)
     policy  = optional(string, "v=DMARC1; p=reject;")
-    ttl = optional(number, 600)
+    ttl     = optional(number, 600)
   })
   default = {}
 }


### PR DESCRIPTION
- add spf record management - https://github.com/Script47/aws-tf-modules/issues/24
- remove data attr usage - https://github.com/Script47/aws-tf-modules/issues/22
- make zone ID optional and include DNS output - https://github.com/Script47/aws-tf-modules/issues/24