### PR TITLE
feat(static-site): allow optional S3 bucket prefix for static site origin

### DIFF
--- a/acm-certificate/providers.tf
+++ b/acm-certificate/providers.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 6"
       configuration_aliases = [
         aws.acm,

--- a/github-oidc-iam-role/data.tf
+++ b/github-oidc-iam-role/data.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     actions = ["sts:AssumeRoleWithWebIdentity"]
 
     principals {
-      type = "Federated"
+      type        = "Federated"
       identifiers = [data.aws_iam_openid_connect_provider.github.arn]
     }
 
@@ -19,9 +19,9 @@ data "aws_iam_policy_document" "assume_role_policy" {
     }
 
     condition {
-        test     = "StringLike"
-        variable = "token.actions.githubusercontent.com:sub"
-        values   = var.sub      
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = var.sub
     }
   }
 }

--- a/github-oidc-iam-role/iam.tf
+++ b/github-oidc-iam-role/iam.tf
@@ -7,9 +7,9 @@ resource "aws_iam_role" "role" {
 resource "aws_iam_role_policy" "policy" {
   count = var.policy != null ? 1 : 0
 
-  name     = var.policy_name
-  role     = aws_iam_role.role.id
-  policy   = var.policy
+  name   = var.policy_name
+  role   = aws_iam_role.role.id
+  policy = var.policy
 }
 
 resource "aws_iam_role_policy_attachment" "policies" {

--- a/github-oidc-iam-role/outputs.tf
+++ b/github-oidc-iam-role/outputs.tf
@@ -8,7 +8,7 @@ output "role" {
 
 output "policy" {
   value = length(aws_iam_role_policy.policy) > 0 ? {
-    id  =  aws_iam_role_policy.policy[0].id
+    id   = aws_iam_role_policy.policy[0].id
     name = aws_iam_role_policy.policy[0].name
   } : null
 }

--- a/github-oidc-iam-role/variables.tf
+++ b/github-oidc-iam-role/variables.tf
@@ -19,7 +19,7 @@ variable "policy" {
 variable "policy_arns" {
   type        = set(string)
   description = "Set of IAM policy ARNs to attach to the role"
-  default     = [] 
+  default     = []
 }
 
 variable "sub" {

--- a/guardrails/iam.tf
+++ b/guardrails/iam.tf
@@ -7,8 +7,8 @@ resource "aws_iam_account_password_policy" "this" {
   max_password_age               = var.iam.password_policy.max_password_age
   minimum_password_length        = var.iam.password_policy.minimum_password_length
 
-  require_lowercase_characters   = var.iam.password_policy.require_lowercase_characters
-  require_uppercase_characters   = var.iam.password_policy.require_uppercase_characters
-  require_numbers                = var.iam.password_policy.require_numbers
-  require_symbols                = var.iam.password_policy.require_symbols
+  require_lowercase_characters = var.iam.password_policy.require_lowercase_characters
+  require_uppercase_characters = var.iam.password_policy.require_uppercase_characters
+  require_numbers              = var.iam.password_policy.require_numbers
+  require_symbols              = var.iam.password_policy.require_symbols
 }

--- a/guardrails/providers.tf
+++ b/guardrails/providers.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 6"
     }
   }

--- a/guardrails/variables.tf
+++ b/guardrails/variables.tf
@@ -14,7 +14,7 @@ variable "s3" {
       block_public_acls       = optional(bool, true)
       block_public_policy     = optional(bool, true)
       ignore_public_acls      = optional(bool, true)
-      restrict_public_buckets = optional(bool, true)      
+      restrict_public_buckets = optional(bool, true)
     }), {})
   })
   default = {}
@@ -31,10 +31,10 @@ variable "iam" {
       max_password_age               = optional(number, null)
       minimum_password_length        = optional(number, 12)
 
-      require_lowercase_characters   = optional(bool, true)
-      require_uppercase_characters   = optional(bool, true)
-      require_numbers                = optional(bool, true)
-      require_symbols                = optional(bool, true)
+      require_lowercase_characters = optional(bool, true)
+      require_uppercase_characters = optional(bool, true)
+      require_numbers              = optional(bool, true)
+      require_symbols              = optional(bool, true)
     }), {})
   })
   default = {}

--- a/lambda-function/lambda.tf
+++ b/lambda-function/lambda.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "fn" {
 
   dynamic "logging_config" {
     for_each = var.logs.enabled ? [1] : []
-    
+
     content {
       log_group             = aws_cloudwatch_log_group.logs[0].name
       log_format            = "JSON"
@@ -50,8 +50,8 @@ resource "aws_lambda_function_event_invoke_config" "invoke_config" {
 
   dynamic "destination_config" {
     for_each = (
-    var.async_invoke_config.success_destination_arn != null ||
-    var.async_invoke_config.failure_destination_arn != null
+      var.async_invoke_config.success_destination_arn != null ||
+      var.async_invoke_config.failure_destination_arn != null
     ) ? [1] : []
 
     content {

--- a/lambda-layer/data.tf
+++ b/lambda-layer/data.tf
@@ -13,5 +13,5 @@ data "archive_file" "layer" {
   type        = "zip"
   source_dir  = var.src
   output_path = local.output_path
-  depends_on = [null_resource.create_build_dir]
+  depends_on  = [null_resource.create_build_dir]
 }

--- a/lambda-layer/providers.tf
+++ b/lambda-layer/providers.tf
@@ -10,7 +10,7 @@ terraform {
     null = {
       source  = "hashicorp/null"
       version = ">= 3.0.0, < 4.0.0"
-    }    
+    }
 
     archive = {
       source  = "hashicorp/archive"

--- a/lambda-layer/variables.tf
+++ b/lambda-layer/variables.tf
@@ -10,14 +10,14 @@ variable "description" {
 }
 
 variable "runtimes" {
-  type = list(string)
-  default = ["nodejs24.x"]
+  type        = list(string)
+  default     = ["nodejs24.x"]
   description = "The compatible runtimes"
 }
 
 variable "architectures" {
-  type = list(string)
-  default = ["arm64"]
+  type        = list(string)
+  default     = ["arm64"]
   description = "The compatible architectures"
 }
 

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -1,24 +1,24 @@
 variable "name" {
-  type = string
+  type        = string
   description = "The name of your queue"
 }
 
 variable "max_size_in_bytes" {
-  type    = number
-  default = 262144
+  type        = number
+  default     = 262144
   description = "Defaults to 256 KiB"
 }
 
 variable "retention_in_seconds" {
-  type    = number
-  default = 604800
+  type        = number
+  default     = 604800
   description = "Duration a message is kept in the queue. Defaults to 7 days"
 }
 
 # delay_seconds
 variable "initial_visibility_delay_in_seconds" {
-  type    = number
-  default = 0
+  type        = number
+  default     = 0
   description = "Duration a message is initially hidden before becoming visible in the queue"
 }
 
@@ -31,24 +31,24 @@ variable "poll_timeout_in_seconds" {
 
 # visibility_timeout_seconds
 variable "lock_timeout_in_seconds" {
-  type    = number
-  default = 30
+  type        = number
+  default     = 30
   description = "Duration an in-flight message is hidden from other consumers after being consumed"
 }
 
 variable "dlq" {
   type = object({
-    create = optional(bool, false)
-    max_receive_count = optional(number, 3)
+    create               = optional(bool, false)
+    max_receive_count    = optional(number, 3)
     retention_in_seconds = optional(number, 1209600)
   })
-  default = {}
+  default     = {}
   description = "DLQ configuration for your queue"
 }
 
 
 variable "tags" {
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
   description = "The tags to apply to all resources created"
 }

--- a/static-site/cloudfront.tf
+++ b/static-site/cloudfront.tf
@@ -27,6 +27,7 @@ resource "aws_cloudfront_distribution" "static_site" {
     origin_id                = local.origin_id
     origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
     domain_name              = aws_s3_bucket.static_site.bucket_regional_domain_name
+    origin_path              = var.bucket_prefix != "" ? "/${var.bucket_prefix}" : ""
   }
 
   default_cache_behavior {

--- a/static-site/cloudfront.tf
+++ b/static-site/cloudfront.tf
@@ -27,7 +27,7 @@ resource "aws_cloudfront_distribution" "static_site" {
     origin_id                = local.origin_id
     origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
     domain_name              = aws_s3_bucket.static_site.bucket_regional_domain_name
-    origin_path              = var.bucket_prefix != "" ? "/${var.bucket_prefix}" : ""
+    origin_path              = var.origin_path != "" ? "/${var.origin_path}" : ""
   }
 
   default_cache_behavior {

--- a/static-site/providers.tf
+++ b/static-site/providers.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 6"
       configuration_aliases = [
         aws.acm,

--- a/static-site/s3.tf
+++ b/static-site/s3.tf
@@ -1,4 +1,6 @@
 resource "aws_s3_bucket" "static_site" {
+  count = var.existing_bucket_name == "" ? 1 : 0
+
   bucket        = local.bucket_name
   force_destroy = true
   tags          = var.tags
@@ -6,7 +8,7 @@ resource "aws_s3_bucket" "static_site" {
 }
 
 resource "aws_s3_bucket_public_access_block" "static_site" {
-  bucket                  = aws_s3_bucket.static_site.id
+  bucket                  = var.existing_bucket_name != "" ? var.existing_bucket_name : aws_s3_bucket.static_site[0].id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -15,7 +17,7 @@ resource "aws_s3_bucket_public_access_block" "static_site" {
 }
 
 resource "aws_s3_bucket_policy" "static_site" {
-  bucket   = aws_s3_bucket.static_site.bucket
+  bucket   = var.existing_bucket_name != "" ? var.existing_bucket_name : aws_s3_bucket.static_site[0].bucket
   policy   = data.aws_iam_policy_document.cloudfront_to_s3.json
   provider = aws.default
 }

--- a/static-site/s3.tf
+++ b/static-site/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "static_site" {
-  count = var.existing_bucket_name == "" ? 1 : 0
+  count = var.create_bucket ? 1 : 0
 
   bucket        = local.bucket_name
   force_destroy = true
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "static_site" {
 }
 
 resource "aws_s3_bucket_public_access_block" "static_site" {
-  bucket                  = var.existing_bucket_name != "" ? var.existing_bucket_name : aws_s3_bucket.static_site[0].id
+  bucket                  = var.bucket_name != "" ? var.bucket_name : aws_s3_bucket.static_site[0].id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -17,7 +17,7 @@ resource "aws_s3_bucket_public_access_block" "static_site" {
 }
 
 resource "aws_s3_bucket_policy" "static_site" {
-  bucket   = var.existing_bucket_name != "" ? var.existing_bucket_name : aws_s3_bucket.static_site[0].bucket
+  bucket   = var.bucket_name != "" ? var.bucket_name : aws_s3_bucket.static_site[0].bucket
   policy   = data.aws_iam_policy_document.cloudfront_to_s3.json
   provider = aws.default
 }

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -46,3 +46,9 @@ variable "tags" {
   type        = map(string)
   description = "The tags to apply to all resources created"
 }
+
+variable "bucket_prefix" {
+  type        = string
+  description = "Optional prefix inside the S3 bucket for static site files"
+  default     = ""
+}

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -64,3 +64,9 @@ variable "origin_path" {
   description = "Optional prefix inside the S3 bucket for static site files"
   default     = ""
 }
+
+variable "existing_bucket_name" {
+  description = "Use an existing S3 bucket instead of creating a new one"
+  type = string
+  default = ""
+}

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -47,7 +47,7 @@ variable "tags" {
   description = "The tags to apply to all resources created"
 }
 
-variable "bucket_prefix" {
+variable "origin_path" {
   type        = string
   description = "Optional prefix inside the S3 bucket for static site files"
   default     = ""

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -1,6 +1,6 @@
 variable "bucket_name" {
   type        = string
-  description = "The name of the bucket that will store your static site files. If omitted the bucket name will match the domain name"
+  description = "The name of the S3 bucket. If create_bucket is false, this must refer to an existing bucket. If omitted, the bucket name will match the domain name"
   default     = ""
 }
 
@@ -65,8 +65,8 @@ variable "origin_path" {
   default     = ""
 }
 
-variable "existing_bucket_name" {
-  description = "Use an existing S3 bucket instead of creating a new one"
-  type = string
-  default = ""
+variable "create_bucket" {
+  description = "Whether to create a new S3 bucket or use an existing one"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
Summary

Adds support for an optional bucket_prefix variable to allow serving static site content from a specific prefix inside the S3 bucket.

Changes

Added bucket_prefix variable

Updated CloudFront origin configuration to support prefix using origin_path

Backward Compatibility

If bucket_prefix is empty (default), the module behaves exactly as before and serves content from the root of the bucket.

Related Issue

Fixes #12